### PR TITLE
add tests

### DIFF
--- a/as-client/pom.xml
+++ b/as-client/pom.xml
@@ -61,6 +61,23 @@
 <!--            <artifactId>mail</artifactId>-->
 <!--            <version>1.5.0-b01</version>-->
 <!--        </dependency>-->
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/as-client/src/main/java/tests/BusinessLogicTest.java
+++ b/as-client/src/main/java/tests/BusinessLogicTest.java
@@ -1,0 +1,42 @@
+package tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import translator.*;
+
+/***
+ * BUSINESS LOGIC TESTING
+ * Class for testing main functions of translator
+ ***/
+
+public class BusinessLogicTest {
+
+    // Testing russia to english translate
+    @Test
+    public void ruToEngTranslate() {
+        TranslateInterface translateInterface = new RussiaToEnglishTranslate();
+        Assert.assertEquals(translateInterface.translate("кошка"), "cat");
+    }
+
+    // Testing english to russia translate
+    @Test
+    public void engToRuTranslate() {
+        TranslateInterface translateInterface = new EnglishToRussiaTranslate();
+        Assert.assertEquals(translateInterface.translate("cat"), "кошка");
+    }
+
+    // Testing if word is unknown in russia to english translate returns null
+    @Test
+    public void ruToEngTranslateNull() {
+        TranslateInterface translateInterface = new RussiaToEnglishTranslate();
+        Assert.assertNull(translateInterface.translate("абв"));
+    }
+
+    // Testing if word is unknown in english to russia translate returns null
+    @Test
+    public void enToRuTranslateNull() {
+        TranslateInterface translateInterface = new RussiaToEnglishTranslate();
+        Assert.assertNull(translateInterface.translate("abc"));
+    }
+
+}

--- a/as-client/src/main/java/tests/UnitTests.java
+++ b/as-client/src/main/java/tests/UnitTests.java
@@ -1,0 +1,109 @@
+package tests;
+
+import lombok.SneakyThrows;
+import org.junit.Assert;
+import org.junit.Test;
+import translator.EnglishToRussiaTranslate;
+import translator.LanguageStrategy;
+import translator.RussiaToEnglishTranslate;
+import translator.TranslateInterface;
+import translator.mail.*;
+
+import javax.mail.Session;
+import javax.mail.internet.MimeMessage;
+import java.util.Properties;
+
+/***
+ * UNIT TESTING
+ * Class for testing functions realizing our buiseness logic
+ ***/
+
+public class UnitTests {
+
+    private final EmailUtil emailUtil;
+    private final Session session;
+    private final Mail mail;
+
+    public UnitTests() {
+
+        // create a instance of Mail for testing
+        mail = Mail.builder()
+                .from("some@gmail.com")
+                .host("localhost")
+                .message("TEST")
+                .to("to@gmail.com")
+                .subject("TEST SUBJECT")
+                .build();
+
+        // get default session
+        session = Session.getDefaultInstance(new GmailEmail().getProps());
+        // get emailUtil for testing
+        emailUtil = new EmailUtil(new FactoryGmail(), mail);
+    }
+
+    // Testing singleton realization of PasswordAuthenticator
+    @Test
+    public void singletonPasswordAuthenticatorTest() {
+        MailSenderAuthenticator authenticator1 =
+                PasswordAuthenticator.getPasswordAuthenticator("some@gmail.com", "123");
+
+        MailSenderAuthenticator authenticator2 =
+                PasswordAuthenticator.getPasswordAuthenticator("some@gmail.com", "123");
+
+        Assert.assertEquals(authenticator1, authenticator2);
+    }
+
+    // testing strategy choosing translator
+    // testing that by "ru" from and "en" to creating right class
+    @Test
+    public void strategyTestChooseRuToEn() {
+        TranslateInterface translateInterface = new LanguageStrategy().getTranslator("ru", "en");
+        Assert.assertTrue(translateInterface instanceof RussiaToEnglishTranslate);
+    }
+
+    // testing strategy choosing translator
+    // testing that by "en" from and "ru" to creating right class
+    @Test
+    public void strategyTestChooseEnToRu() {
+        TranslateInterface translateInterface = new LanguageStrategy().getTranslator("en", "ru");
+        Assert.assertTrue(translateInterface instanceof EnglishToRussiaTranslate);
+    }
+
+    // testing strategy choosing translator
+    // testing that by incorrect params returns null
+    @Test
+    public void strategyTestChooseNull() {
+        TranslateInterface translateInterface = new LanguageStrategy().getTranslator("aa", "bb");
+        Assert.assertNull(translateInterface);
+    }
+
+    // test that gmail properties is correct
+    @Test
+    public void testGmailProps() {
+        AbstractMailFactory factory = new FactoryGmail();
+        Properties properties = factory.getSmtp().getProps();
+        Assert.assertEquals(properties.getProperty("mail.smtp.host"), "smtp.gmail.com");
+        Assert.assertEquals(properties.getProperty("mail.smtp.socketFactory.port"), "465");
+        Assert.assertEquals(properties.getProperty("mail.smtp.socketFactory.class"),
+                "javax.net.ssl.SSLSocketFactory");
+        Assert.assertEquals(properties.getProperty("mail.smtp.auth"), "true");
+        Assert.assertEquals(properties.getProperty("mail.smtp.port"), "465");
+    }
+
+    // test that subject of the message is correct
+    @SneakyThrows
+    @Test
+    public void emailSubjectTest() {
+        MimeMessage message = emailUtil.createMessage(session);
+        Assert.assertEquals(message.getSubject(), mail.getSubject());
+    }
+
+    // test that text of the message is correct
+    @SneakyThrows
+    @Test
+    public void emailTextTest() {
+        MimeMessage message = emailUtil.createMessage(session);
+        Assert.assertEquals(message.getContent(), mail.getMessage());
+    }
+
+}


### PR DESCRIPTION
Класс **BusinessLogicTest** предназначен для тестов бизнес логики.
Класс **UnitTests** преднозначен для юнит тестов.
В рамках тестирования бизнес логики тестируется перевод с английского на русский и с русского на английский. Что существующее слово в словаре переводится правильно, а если слово отсутсвует в словаре, то возвращается null.
В рамках юнит тестирования тестируется реализация синглтона класса PasswordAuthenticator, стратегия выбора переводчика в классе LanguageStrategy, а так же util методов для отправки писем.